### PR TITLE
fix: component ui badge 사용

### DIFF
--- a/src/components/editor/elements/text.tsx
+++ b/src/components/editor/elements/text.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { Badge, Trash } from "lucide-react";
+import { Trash } from "lucide-react";
 import React from "react";
 import { useEditor } from "~/components/editor/provider";
 import type { EditorElement } from "~/components/editor/type";
+import { Badge } from "~/components/ui/badge";
 import { cn } from "~/lib/utils";
 
 type Props = {


### PR DESCRIPTION
Text 컴포넌트에서 lucide-icon의 Badge 대신 ui 컴포넌트 Badge를 사용하도록 수정합니다.

## before
<img width="468" alt="Screenshot 2024-08-02 at 9 52 41 AM" src="https://github.com/user-attachments/assets/d1e79862-953f-49f6-8f4b-3a1a7ab33635">

## after
<img width="465" alt="Screenshot 2024-08-02 at 9 52 23 AM" src="https://github.com/user-attachments/assets/42414345-a7c6-43b0-b43a-dbf9260f20d2">
