### PR TITLE
feature/inv-78 엘리먼트 > 컨테이너 > 레이아웃 설정

### DIFF
--- a/src/components/editor/constant.ts
+++ b/src/components/editor/constant.ts
@@ -5,6 +5,12 @@ import type {
 } from "~/components/editor/type";
 
 export const defaultStyles: React.CSSProperties = {
+  display: "flex",
+  gap: 10,
+  paddingTop: 10,
+  paddingRight: 10,
+  paddingBottom: 10,
+  paddingLeft: 10,
   backgroundPosition: "center",
   objectFit: "cover",
   backgroundRepeat: "no-repeat",

--- a/src/components/editor/constant.ts
+++ b/src/components/editor/constant.ts
@@ -6,6 +6,8 @@ import type {
 
 export const defaultStyles: React.CSSProperties = {
   display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
   gap: 10,
   paddingTop: 10,
   paddingRight: 10,

--- a/src/components/editor/elements/container.tsx
+++ b/src/components/editor/elements/container.tsx
@@ -45,7 +45,7 @@ export default function Container({ element }: Props) {
               type: "container",
               id: nanoid(),
               name: "Container",
-              styles: { ...defaultStyles, display: "flex" },
+              styles: { ...defaultStyles, display: "flex", gap: 10 },
               content: [],
             },
           },

--- a/src/components/editor/elements/container.tsx
+++ b/src/components/editor/elements/container.tsx
@@ -45,7 +45,7 @@ export default function Container({ element }: Props) {
               type: "container",
               id: nanoid(),
               name: "Container",
-              styles: { ...defaultStyles },
+              styles: { ...defaultStyles, display: "flex" },
               content: [],
             },
           },

--- a/src/components/editor/elements/container.tsx
+++ b/src/components/editor/elements/container.tsx
@@ -45,7 +45,7 @@ export default function Container({ element }: Props) {
               type: "container",
               id: nanoid(),
               name: "Container",
-              styles: { ...defaultStyles, display: "flex", gap: 10 },
+              styles: { ...defaultStyles },
               content: [],
             },
           },

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -242,10 +242,21 @@ function FlexBoxSection() {
 }
 
 function PaddingSection() {
-  const [isPaddingIndividual, setIsPaddingIndividual] = useState(false);
-
   const { editor, dispatch } = useEditor();
   const element = editor.state.selectedElement;
+
+  const [isPaddingIndividual, setIsPaddingIndividual] = useState(false);
+
+  const togglePaddingIndividual = (isIndividual: boolean) => {
+    dispatch({
+      type: "UPDATE_ELEMENT_STYLE",
+      payload: {
+        paddingRight: element.styles.paddingRight,
+        paddingBottom: element.styles.paddingTop,
+      },
+    });
+    setIsPaddingIndividual(isIndividual);
+  };
 
   return (
     <div className="grid w-full grid-cols-9 gap-1">
@@ -320,7 +331,7 @@ function PaddingSection() {
             <Toggle
               size="xs"
               pressed={isPaddingIndividual}
-              onPressedChange={setIsPaddingIndividual}
+              onPressedChange={togglePaddingIndividual}
             >
               <PaddingIndividualIcon />
             </Toggle>

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -31,8 +31,10 @@ import { cn } from "~/lib/utils";
 
 export default function LayoutSetting() {
   return (
-    <div className="border-t px-6 py-4">
-      <h4 className="mb-3 text-sm font-medium">레이아웃 설정</h4>
+    <div className="space-y-1 border-t px-6 py-4">
+      <div className="flex h-10 items-center">
+        <h4 className="text-sm font-medium">레이아웃 설정</h4>
+      </div>
       <FlexBoxSection />
       <PaddingSection />
     </div>
@@ -218,7 +220,7 @@ function FlexBoxSection() {
       <div className="col-span-4 row-span-1 flex items-start">
         <FlexToggleGroup element={element} />
       </div>
-      <div className="col-span-5 row-span-2 flex items-start">
+      <div className="col-span-4 row-span-2 flex items-start">
         <AlignInput />
       </div>
       <div className="col-span-4 row-span-1">
@@ -255,7 +257,7 @@ function PaddingSection() {
               type="number"
               value={element.styles.paddingLeft}
               onChange={(e) => {
-                const newValue = +e.target.value;
+                const newValue = e.target.valueAsNumber;
                 dispatch({
                   type: "UPDATE_ELEMENT_STYLE",
                   payload: { paddingLeft: newValue, paddingRight: newValue },
@@ -270,7 +272,7 @@ function PaddingSection() {
               type="number"
               value={element.styles.paddingTop}
               onChange={(e) => {
-                const newValue = +e.target.value;
+                const newValue = e.target.valueAsNumber;
                 dispatch({
                   type: "UPDATE_ELEMENT_STYLE",
                   payload: { paddingTop: newValue, paddingBottom: newValue },
@@ -286,7 +288,13 @@ function PaddingSection() {
             <IconInput
               id="pl_input"
               type="number"
-              defaultValue={10}
+              value={element.styles.paddingLeft}
+              onChange={(e) => {
+                dispatch({
+                  type: "UPDATE_ELEMENT_STYLE",
+                  payload: { paddingLeft: e.target.valueAsNumber },
+                });
+              }}
               icon={<PaddingLeftIcon />}
             />
           </div>
@@ -294,7 +302,13 @@ function PaddingSection() {
             <IconInput
               id="pt_input"
               type="number"
-              defaultValue={10}
+              value={element.styles.paddingTop}
+              onChange={(e) => {
+                dispatch({
+                  type: "UPDATE_ELEMENT_STYLE",
+                  payload: { paddingTop: e.target.valueAsNumber },
+                });
+              }}
               icon={<PaddingTopIcon />}
             />
           </div>
@@ -319,7 +333,13 @@ function PaddingSection() {
             <IconInput
               id="pr_input"
               type="number"
-              defaultValue={10}
+              value={element.styles.paddingRight}
+              onChange={(e) => {
+                dispatch({
+                  type: "UPDATE_ELEMENT_STYLE",
+                  payload: { paddingRight: e.target.valueAsNumber },
+                });
+              }}
               icon={<PaddingRightIcon />}
             />
           </div>
@@ -327,7 +347,13 @@ function PaddingSection() {
             <IconInput
               id="pb_input"
               type="number"
-              defaultValue={10}
+              value={element.styles.paddingBottom}
+              onChange={(e) => {
+                dispatch({
+                  type: "UPDATE_ELEMENT_STYLE",
+                  payload: { paddingBottom: e.target.valueAsNumber },
+                });
+              }}
               icon={<PaddingBottomIcon />}
             />
           </div>

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -1,13 +1,9 @@
 "use client";
 
-import {
-  ArrowDownIcon,
-  ArrowRightIcon,
-  CornerDownLeftIcon,
-} from "lucide-react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useEditor } from "~/components/editor/provider";
 import AlignInputBox from "~/components/editor/ui/align-input-box";
+import FlexToggleGroup from "~/components/editor/ui/flex-toggle-group";
 import { IconInput } from "~/components/editor/ui/input";
 import {
   GapIcon,
@@ -20,7 +16,6 @@ import {
   PaddingTopIcon,
 } from "~/components/ui/icons";
 import { Toggle } from "~/components/ui/toggle";
-import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
 import TooltipSimple from "~/components/ui/tooltip-simple";
 
 export default function LayoutSetting() {
@@ -32,79 +27,6 @@ export default function LayoutSetting() {
       <FlexBoxSection />
       <PaddingSection />
     </div>
-  );
-}
-
-function FlexToggleGroup({
-  value,
-  onChangeValue,
-}: {
-  value: { flexWrap?: string; flexDirection?: string };
-  onChangeValue: (value: {
-    flexWrap: "wrap" | "nowrap";
-    flexDirection: "row" | "column";
-  }) => void;
-}) {
-  const toggleValue = useMemo(() => {
-    if (value.flexWrap === "wrap") {
-      return "wrap";
-    }
-
-    return value.flexDirection ?? "row";
-  }, [value]);
-
-  const onValueChange = (newValue: "wrap" | "row" | "column") => {
-    if (!newValue) {
-      return;
-    }
-
-    if (newValue === "wrap") {
-      onChangeValue({
-        flexWrap: "wrap",
-        flexDirection: "row",
-      });
-      return;
-    }
-
-    onChangeValue({
-      flexWrap: "nowrap",
-      flexDirection: newValue,
-    });
-  };
-
-  return (
-    <ToggleGroup
-      type="single"
-      className="flex gap-[1px] rounded-sm ring-border ring-offset-1 hover:ring-1"
-      value={toggleValue}
-      onValueChange={onValueChange}
-    >
-      <TooltipSimple text="Vertical layout">
-        <div>
-          <ToggleGroupItem
-            size="xs"
-            value="column"
-            aria-label="Vertical layout"
-          >
-            <ArrowDownIcon size={13} />
-          </ToggleGroupItem>
-        </div>
-      </TooltipSimple>
-      <TooltipSimple text="Horizontal layout">
-        <div>
-          <ToggleGroupItem size="xs" value="row" aria-label="Horizontal layout">
-            <ArrowRightIcon size={13} />
-          </ToggleGroupItem>
-        </div>
-      </TooltipSimple>
-      <TooltipSimple text="Wrap">
-        <div>
-          <ToggleGroupItem size="xs" value="wrap" aria-label="Wrap">
-            <CornerDownLeftIcon size={13} />
-          </ToggleGroupItem>
-        </div>
-      </TooltipSimple>
-    </ToggleGroup>
   );
 }
 

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -12,7 +12,6 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useEditor } from "~/components/editor/provider";
-import type { EditorElement } from "~/components/editor/type";
 import { IconInput } from "~/components/editor/ui/input";
 import {
   GapIcon,
@@ -157,16 +156,23 @@ function AlignInput({
   );
 }
 
-function FlexToggleGroup({ element }: { element: EditorElement }) {
-  const { dispatch } = useEditor();
-
-  const value = useMemo(() => {
-    if (element.styles.flexWrap === "wrap") {
+function FlexToggleGroup({
+  value,
+  onChangeValue,
+}: {
+  value: { flexWrap?: string; flexDirection?: string };
+  onChangeValue: (value: {
+    flexWrap: "wrap" | "nowrap";
+    flexDirection: "row" | "column";
+  }) => void;
+}) {
+  const toggleValue = useMemo(() => {
+    if (value.flexWrap === "wrap") {
       return "wrap";
     }
 
-    return element.styles.flexDirection ?? "row";
-  }, [element.styles]);
+    return value.flexDirection ?? "row";
+  }, [value]);
 
   const onValueChange = (newValue: "wrap" | "row" | "column") => {
     if (!newValue) {
@@ -174,22 +180,16 @@ function FlexToggleGroup({ element }: { element: EditorElement }) {
     }
 
     if (newValue === "wrap") {
-      dispatch({
-        type: "UPDATE_ELEMENT_STYLE",
-        payload: {
-          flexWrap: "wrap",
-          flexDirection: "row",
-        },
+      onChangeValue({
+        flexWrap: "wrap",
+        flexDirection: "row",
       });
       return;
     }
 
-    dispatch({
-      type: "UPDATE_ELEMENT_STYLE",
-      payload: {
-        flexWrap: "nowrap",
-        flexDirection: newValue,
-      },
+    onChangeValue({
+      flexWrap: "nowrap",
+      flexDirection: newValue,
     });
   };
 
@@ -197,7 +197,7 @@ function FlexToggleGroup({ element }: { element: EditorElement }) {
     <ToggleGroup
       type="single"
       className="flex gap-[1px] rounded-sm ring-border ring-offset-1 hover:ring-1"
-      value={value}
+      value={toggleValue}
       onValueChange={onValueChange}
     >
       <TooltipSimple text="Vertical layout">
@@ -236,7 +236,21 @@ function FlexBoxSection() {
   return (
     <div className="grid w-full grid-cols-9 gap-1">
       <div className="col-span-4 row-span-1 flex items-start">
-        <FlexToggleGroup element={element} />
+        <FlexToggleGroup
+          value={{
+            flexDirection: element.styles.flexDirection,
+            flexWrap: element.styles.flexWrap,
+          }}
+          onChangeValue={(value) => {
+            dispatch({
+              type: "UPDATE_ELEMENT_STYLE",
+              payload: {
+                flexDirection: value.flexDirection,
+                flexWrap: value.flexWrap,
+              },
+            });
+          }}
+        />
       </div>
       <div className="col-span-4 row-span-2 flex items-start">
         <AlignInput

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -10,7 +10,9 @@ import {
   DotIcon,
   type LucideProps,
 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useEditor } from "~/components/editor/provider";
+import type { EditorElement } from "~/components/editor/type";
 import { IconInput } from "~/components/editor/ui/input";
 import {
   GapIcon,
@@ -125,18 +127,54 @@ function AlignInput() {
   );
 }
 
-function FlexToggleGroup() {
+function FlexToggleGroup({ element }: { element: EditorElement }) {
+  const { dispatch } = useEditor();
+
+  const value = useMemo(() => {
+    if (element.styles.flexWrap === "wrap") {
+      return "wrap";
+    }
+
+    return element.styles.flexDirection ?? "row";
+  }, [element.styles]);
+
+  const onValueChange = (newValue: "wrap" | "row" | "column") => {
+    if (!newValue) {
+      return;
+    }
+
+    if (newValue === "wrap") {
+      dispatch({
+        type: "UPDATE_ELEMENT_STYLE",
+        payload: {
+          flexWrap: "wrap",
+          flexDirection: "row",
+        },
+      });
+      return;
+    }
+
+    dispatch({
+      type: "UPDATE_ELEMENT_STYLE",
+      payload: {
+        flexWrap: "nowrap",
+        flexDirection: newValue,
+      },
+    });
+  };
+
   return (
     <ToggleGroup
       type="single"
-      className="gap-[1px] rounded-sm ring-border ring-offset-1 hover:ring-1"
-      defaultValue="flex-col"
+      className="flex gap-[1px] rounded-sm ring-border ring-offset-1 hover:ring-1"
+      value={value}
+      onValueChange={onValueChange}
     >
       <TooltipSimple text="Vertical layout">
         <div>
           <ToggleGroupItem
             size="xs"
-            value="flex-col"
+            value="column"
             aria-label="Vertical layout"
           >
             <ArrowDownIcon size={13} />
@@ -145,18 +183,14 @@ function FlexToggleGroup() {
       </TooltipSimple>
       <TooltipSimple text="Horizontal layout">
         <div>
-          <ToggleGroupItem
-            size="xs"
-            value="flex"
-            aria-label="Horizontal layout"
-          >
+          <ToggleGroupItem size="xs" value="row" aria-label="Horizontal layout">
             <ArrowRightIcon size={13} />
           </ToggleGroupItem>
         </div>
       </TooltipSimple>
       <TooltipSimple text="Wrap">
         <div>
-          <ToggleGroupItem size="xs" value="flex-wrap" aria-label="Wrap">
+          <ToggleGroupItem size="xs" value="wrap" aria-label="Wrap">
             <CornerDownLeftIcon size={13} />
           </ToggleGroupItem>
         </div>
@@ -168,12 +202,15 @@ function FlexToggleGroup() {
 export default function LayoutSetting() {
   const [isPaddingIndividual, setIsPaddingIndividual] = useState(false);
 
+  const { editor } = useEditor();
+  const element = editor.state.selectedElement;
+
   return (
     <div className="border-t px-6 py-4">
       <h4 className="mb-3 text-sm font-medium">레이아웃 설정</h4>
       <div className="grid w-full grid-cols-9 gap-1">
         <div className="col-span-4 row-span-1 flex items-start">
-          <FlexToggleGroup />
+          <FlexToggleGroup element={element} />
         </div>
         <div className="col-span-5 row-span-2 flex items-start">
           <AlignInput />

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -107,18 +107,36 @@ const alignConfig = {
   },
 } as const;
 
-function AlignInput() {
+function AlignInput({
+  value,
+  onChangeValue,
+}: {
+  value: { justifyContent?: string; alignItems?: string };
+  onChangeValue: (value: {
+    justifyContent: string;
+    alignItems: string;
+  }) => void;
+}) {
   return (
     <div className="grid grid-cols-3 grid-rows-3 rounded-sm border text-muted-foreground">
       {Object.keys(alignConfig).map((key) => {
         const alignKey = key as keyof typeof alignConfig;
         const { Icon } = alignConfig[alignKey];
-        const isSelected = alignKey === "center_center";
+        const [alignItemValue, justifyValue] = alignKey.split("_");
+        const isSelected =
+          value.alignItems === alignItemValue &&
+          value.justifyContent === justifyValue;
 
         return (
           <div
             key={alignKey}
             className="group relative flex h-5 w-5 items-center justify-center"
+            onClick={() =>
+              onChangeValue({
+                alignItems: alignItemValue,
+                justifyContent: justifyValue,
+              })
+            }
           >
             <DotIcon
               size={14}
@@ -221,7 +239,21 @@ function FlexBoxSection() {
         <FlexToggleGroup element={element} />
       </div>
       <div className="col-span-4 row-span-2 flex items-start">
-        <AlignInput />
+        <AlignInput
+          value={{
+            alignItems: element.styles.alignItems,
+            justifyContent: element.styles.justifyContent,
+          }}
+          onChangeValue={(value) => {
+            dispatch({
+              type: "UPDATE_ELEMENT_STYLE",
+              payload: {
+                alignItems: value.alignItems,
+                justifyContent: value.justifyContent,
+              },
+            });
+          }}
+        />
       </div>
       <div className="col-span-4 row-span-1">
         <IconInput
@@ -231,7 +263,7 @@ function FlexBoxSection() {
           onChange={(e) =>
             dispatch({
               type: "UPDATE_ELEMENT_STYLE",
-              payload: { gap: e.target.value },
+              payload: { gap: e.target.valueAsNumber },
             })
           }
           icon={<GapIcon />}

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -202,7 +202,7 @@ function FlexToggleGroup({ element }: { element: EditorElement }) {
 export default function LayoutSetting() {
   const [isPaddingIndividual, setIsPaddingIndividual] = useState(false);
 
-  const { editor } = useEditor();
+  const { editor, dispatch } = useEditor();
   const element = editor.state.selectedElement;
 
   return (
@@ -219,7 +219,13 @@ export default function LayoutSetting() {
           <IconInput
             id="gap_input"
             type="number"
-            defaultValue={10}
+            value={element.styles.gap}
+            onChange={(e) =>
+              dispatch({
+                type: "UPDATE_ELEMENT_STYLE",
+                payload: { gap: e.target.value },
+              })
+            }
             icon={<GapIcon />}
           />
         </div>

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import {
-  AlignCenterIcon,
-  AlignLeftIcon,
-  AlignRight,
   ArrowDownIcon,
   ArrowRightIcon,
   CornerDownLeftIcon,
-  DotIcon,
-  type LucideProps,
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useEditor } from "~/components/editor/provider";
+import AlignInputBox from "~/components/editor/ui/align-input-box";
 import { IconInput } from "~/components/editor/ui/input";
 import {
   GapIcon,
@@ -26,7 +22,6 @@ import {
 import { Toggle } from "~/components/ui/toggle";
 import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
 import TooltipSimple from "~/components/ui/tooltip-simple";
-import { cn } from "~/lib/utils";
 
 export default function LayoutSetting() {
   return (
@@ -36,122 +31,6 @@ export default function LayoutSetting() {
       </div>
       <FlexBoxSection />
       <PaddingSection />
-    </div>
-  );
-}
-
-const alignConfig = {
-  start_start: {
-    style: {
-      justifyContent: "flex-start",
-      alignItems: "flex-start",
-    },
-    Icon: (props: LucideProps) => <AlignLeftIcon {...props} />,
-  },
-  start_center: {
-    style: {
-      justifyContent: "flex-start",
-      alignItems: "center",
-    },
-    Icon: (props: LucideProps) => <AlignCenterIcon {...props} />,
-  },
-  start_end: {
-    style: {
-      justifyContent: "flex-start",
-      alignItems: "flex-end",
-    },
-    Icon: (props: LucideProps) => <AlignRight {...props} />,
-  },
-  center_start: {
-    style: {
-      justifyContent: "center",
-      alignItems: "flex-start",
-    },
-    Icon: (props: LucideProps) => <AlignLeftIcon {...props} />,
-  },
-  center_center: {
-    style: {
-      justifyContent: "center",
-      alignItems: "center",
-    },
-    Icon: (props: LucideProps) => <AlignCenterIcon {...props} />,
-  },
-  center_end: {
-    style: {
-      justifyContent: "center",
-      alignItems: "flex-end",
-    },
-    Icon: (props: LucideProps) => <AlignRight {...props} />,
-  },
-  end_start: {
-    style: {
-      justifyContent: "flex-end",
-      alignItems: "flex-start",
-    },
-    Icon: (props: LucideProps) => <AlignLeftIcon {...props} />,
-  },
-  end_center: {
-    style: {
-      justifyContent: "flex-end",
-      alignItems: "center",
-    },
-    Icon: (props: LucideProps) => <AlignCenterIcon {...props} />,
-  },
-  end_end: {
-    style: {
-      justifyContent: "flex-end",
-      alignItems: "flex-end",
-    },
-    Icon: (props: LucideProps) => <AlignRight {...props} />,
-  },
-} as const;
-
-function AlignInput({
-  value,
-  onChangeValue,
-}: {
-  value: { justifyContent?: string; alignItems?: string };
-  onChangeValue: (value: {
-    justifyContent: string;
-    alignItems: string;
-  }) => void;
-}) {
-  return (
-    <div className="grid grid-cols-3 grid-rows-3 rounded-sm border text-muted-foreground">
-      {Object.keys(alignConfig).map((key) => {
-        const alignKey = key as keyof typeof alignConfig;
-        const { Icon } = alignConfig[alignKey];
-        const [alignItemValue, justifyValue] = alignKey.split("_");
-        const isSelected =
-          value.alignItems === alignItemValue &&
-          value.justifyContent === justifyValue;
-
-        return (
-          <div
-            key={alignKey}
-            className="group relative flex h-5 w-5 items-center justify-center"
-            onClick={() =>
-              onChangeValue({
-                alignItems: alignItemValue,
-                justifyContent: justifyValue,
-              })
-            }
-          >
-            <DotIcon
-              size={14}
-              className={cn("group-hover:hidden", isSelected && "hidden")}
-            />
-            <div
-              className={cn(
-                "absolute inset-0 hidden items-center justify-center group-hover:flex",
-                isSelected && "flex text-foreground",
-              )}
-            >
-              <Icon size={16} />
-            </div>
-          </div>
-        );
-      })}
     </div>
   );
 }
@@ -253,7 +132,7 @@ function FlexBoxSection() {
         />
       </div>
       <div className="col-span-4 row-span-2 flex items-start">
-        <AlignInput
+        <AlignInputBox
           value={{
             alignItems: element.styles.alignItems,
             justifyContent: element.styles.justifyContent,

--- a/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
+++ b/src/components/editor/sidebar-element-settings-tab/layout-setting.tsx
@@ -29,6 +29,16 @@ import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
 import TooltipSimple from "~/components/ui/tooltip-simple";
 import { cn } from "~/lib/utils";
 
+export default function LayoutSetting() {
+  return (
+    <div className="border-t px-6 py-4">
+      <h4 className="mb-3 text-sm font-medium">레이아웃 설정</h4>
+      <FlexBoxSection />
+      <PaddingSection />
+    </div>
+  );
+}
+
 const alignConfig = {
   start_start: {
     style: {
@@ -199,109 +209,130 @@ function FlexToggleGroup({ element }: { element: EditorElement }) {
   );
 }
 
-export default function LayoutSetting() {
+function FlexBoxSection() {
+  const { editor, dispatch } = useEditor();
+  const element = editor.state.selectedElement;
+
+  return (
+    <div className="grid w-full grid-cols-9 gap-1">
+      <div className="col-span-4 row-span-1 flex items-start">
+        <FlexToggleGroup element={element} />
+      </div>
+      <div className="col-span-5 row-span-2 flex items-start">
+        <AlignInput />
+      </div>
+      <div className="col-span-4 row-span-1">
+        <IconInput
+          id="gap_input"
+          type="number"
+          value={element.styles.gap}
+          onChange={(e) =>
+            dispatch({
+              type: "UPDATE_ELEMENT_STYLE",
+              payload: { gap: e.target.value },
+            })
+          }
+          icon={<GapIcon />}
+        />
+      </div>
+    </div>
+  );
+}
+
+function PaddingSection() {
   const [isPaddingIndividual, setIsPaddingIndividual] = useState(false);
 
   const { editor, dispatch } = useEditor();
   const element = editor.state.selectedElement;
 
   return (
-    <div className="border-t px-6 py-4">
-      <h4 className="mb-3 text-sm font-medium">레이아웃 설정</h4>
-      <div className="grid w-full grid-cols-9 gap-1">
-        <div className="col-span-4 row-span-1 flex items-start">
-          <FlexToggleGroup element={element} />
-        </div>
-        <div className="col-span-5 row-span-2 flex items-start">
-          <AlignInput />
-        </div>
-        <div className="col-span-4 row-span-1">
-          <IconInput
-            id="gap_input"
-            type="number"
-            value={element.styles.gap}
-            onChange={(e) =>
-              dispatch({
-                type: "UPDATE_ELEMENT_STYLE",
-                payload: { gap: e.target.value },
-              })
-            }
-            icon={<GapIcon />}
-          />
-        </div>
-        {!isPaddingIndividual ? (
-          <>
-            <div className="col-span-4 row-span-1">
-              <IconInput
-                id="px-input"
-                type="number"
-                defaultValue={10}
-                icon={<PaddingLeftRightIcon />}
-              />
-            </div>
-            <div className="col-span-4 row-span-1">
-              <IconInput
-                id="py_input"
-                type="number"
-                defaultValue={10}
-                icon={<PaddingTopBottomIcon />}
-              />
-            </div>
-          </>
-        ) : (
-          <>
-            <div className="col-span-4 row-span-1">
-              <IconInput
-                id="pl_input"
-                type="number"
-                defaultValue={10}
-                icon={<PaddingLeftIcon />}
-              />
-            </div>
-            <div className="col-span-4 row-span-1">
-              <IconInput
-                id="pt_input"
-                type="number"
-                defaultValue={10}
-                icon={<PaddingTopIcon />}
-              />
-            </div>
-          </>
-        )}
-        <div className="col-span-1 row-span-1">
-          <TooltipSimple text="Individual padding">
-            <div>
-              <Toggle
-                size="xs"
-                pressed={isPaddingIndividual}
-                onPressedChange={setIsPaddingIndividual}
-              >
-                <PaddingIndividualIcon />
-              </Toggle>
-            </div>
-          </TooltipSimple>
-        </div>
-        {isPaddingIndividual && (
-          <>
-            <div className="col-span-4 row-span-1">
-              <IconInput
-                id="pr_input"
-                type="number"
-                defaultValue={10}
-                icon={<PaddingRightIcon />}
-              />
-            </div>
-            <div className="col-span-4 row-span-1">
-              <IconInput
-                id="pb_input"
-                type="number"
-                defaultValue={10}
-                icon={<PaddingBottomIcon />}
-              />
-            </div>
-          </>
-        )}
+    <div className="grid w-full grid-cols-9 gap-1">
+      {!isPaddingIndividual ? (
+        <>
+          <div className="col-span-4 row-span-1">
+            <IconInput
+              id="px-input"
+              type="number"
+              value={element.styles.paddingLeft}
+              onChange={(e) => {
+                const newValue = +e.target.value;
+                dispatch({
+                  type: "UPDATE_ELEMENT_STYLE",
+                  payload: { paddingLeft: newValue, paddingRight: newValue },
+                });
+              }}
+              icon={<PaddingLeftRightIcon />}
+            />
+          </div>
+          <div className="col-span-4 row-span-1">
+            <IconInput
+              id="py_input"
+              type="number"
+              value={element.styles.paddingTop}
+              onChange={(e) => {
+                const newValue = +e.target.value;
+                dispatch({
+                  type: "UPDATE_ELEMENT_STYLE",
+                  payload: { paddingTop: newValue, paddingBottom: newValue },
+                });
+              }}
+              icon={<PaddingTopBottomIcon />}
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="col-span-4 row-span-1">
+            <IconInput
+              id="pl_input"
+              type="number"
+              defaultValue={10}
+              icon={<PaddingLeftIcon />}
+            />
+          </div>
+          <div className="col-span-4 row-span-1">
+            <IconInput
+              id="pt_input"
+              type="number"
+              defaultValue={10}
+              icon={<PaddingTopIcon />}
+            />
+          </div>
+        </>
+      )}
+      <div className="col-span-1 row-span-1">
+        <TooltipSimple text="Individual padding">
+          <div>
+            <Toggle
+              size="xs"
+              pressed={isPaddingIndividual}
+              onPressedChange={setIsPaddingIndividual}
+            >
+              <PaddingIndividualIcon />
+            </Toggle>
+          </div>
+        </TooltipSimple>
       </div>
+      {isPaddingIndividual && (
+        <>
+          <div className="col-span-4 row-span-1">
+            <IconInput
+              id="pr_input"
+              type="number"
+              defaultValue={10}
+              icon={<PaddingRightIcon />}
+            />
+          </div>
+          <div className="col-span-4 row-span-1">
+            <IconInput
+              id="pb_input"
+              type="number"
+              defaultValue={10}
+              icon={<PaddingBottomIcon />}
+            />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/editor/ui/align-input-box.tsx
+++ b/src/components/editor/ui/align-input-box.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  AlignCenterIcon,
+  AlignLeftIcon,
+  AlignRight,
+  DotIcon,
+  type LucideProps,
+} from "lucide-react";
+import { cn } from "~/lib/utils";
+
+const alignConfig = {
+  start_start: {
+    style: {
+      justifyContent: "flex-start",
+      alignItems: "flex-start",
+    },
+    Icon: (props: LucideProps) => <AlignLeftIcon {...props} />,
+  },
+  start_center: {
+    style: {
+      justifyContent: "flex-start",
+      alignItems: "center",
+    },
+    Icon: (props: LucideProps) => <AlignCenterIcon {...props} />,
+  },
+  start_end: {
+    style: {
+      justifyContent: "flex-start",
+      alignItems: "flex-end",
+    },
+    Icon: (props: LucideProps) => <AlignRight {...props} />,
+  },
+  center_start: {
+    style: {
+      justifyContent: "center",
+      alignItems: "flex-start",
+    },
+    Icon: (props: LucideProps) => <AlignLeftIcon {...props} />,
+  },
+  center_center: {
+    style: {
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    Icon: (props: LucideProps) => <AlignCenterIcon {...props} />,
+  },
+  center_end: {
+    style: {
+      justifyContent: "center",
+      alignItems: "flex-end",
+    },
+    Icon: (props: LucideProps) => <AlignRight {...props} />,
+  },
+  end_start: {
+    style: {
+      justifyContent: "flex-end",
+      alignItems: "flex-start",
+    },
+    Icon: (props: LucideProps) => <AlignLeftIcon {...props} />,
+  },
+  end_center: {
+    style: {
+      justifyContent: "flex-end",
+      alignItems: "center",
+    },
+    Icon: (props: LucideProps) => <AlignCenterIcon {...props} />,
+  },
+  end_end: {
+    style: {
+      justifyContent: "flex-end",
+      alignItems: "flex-end",
+    },
+    Icon: (props: LucideProps) => <AlignRight {...props} />,
+  },
+} as const;
+
+export default function AlignInputBox({
+  value,
+  onChangeValue,
+}: {
+  value: { justifyContent?: string; alignItems?: string };
+  onChangeValue: (value: {
+    justifyContent: string;
+    alignItems: string;
+  }) => void;
+}) {
+  return (
+    <div className="grid grid-cols-3 grid-rows-3 rounded-sm border text-muted-foreground">
+      {Object.keys(alignConfig).map((key) => {
+        const alignKey = key as keyof typeof alignConfig;
+        const { Icon } = alignConfig[alignKey];
+        const [alignItemValue, justifyValue] = alignKey.split("_");
+        const isSelected =
+          value.alignItems === alignItemValue &&
+          value.justifyContent === justifyValue;
+
+        return (
+          <div
+            key={alignKey}
+            className="group relative flex h-5 w-5 items-center justify-center"
+            onClick={() =>
+              onChangeValue({
+                alignItems: alignItemValue,
+                justifyContent: justifyValue,
+              })
+            }
+          >
+            <DotIcon
+              size={14}
+              className={cn("group-hover:hidden", isSelected && "hidden")}
+            />
+            <div
+              className={cn(
+                "absolute inset-0 hidden items-center justify-center group-hover:flex",
+                isSelected && "flex text-foreground",
+              )}
+            >
+              <Icon size={16} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/editor/ui/flex-toggle-group.tsx
+++ b/src/components/editor/ui/flex-toggle-group.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  ArrowDownIcon,
+  ArrowRightIcon,
+  CornerDownLeftIcon,
+} from "lucide-react";
+import { useMemo } from "react";
+import { ToggleGroup, ToggleGroupItem } from "~/components/ui/toggle-group";
+import TooltipSimple from "~/components/ui/tooltip-simple";
+
+export default function FlexToggleGroup({
+  value,
+  onChangeValue,
+}: {
+  value: { flexWrap?: string; flexDirection?: string };
+  onChangeValue: (value: {
+    flexWrap: "wrap" | "nowrap";
+    flexDirection: "row" | "column";
+  }) => void;
+}) {
+  const toggleValue = useMemo(() => {
+    if (value.flexWrap === "wrap") {
+      return "wrap";
+    }
+
+    return value.flexDirection ?? "row";
+  }, [value]);
+
+  const onValueChange = (newValue: "wrap" | "row" | "column") => {
+    if (!newValue) {
+      return;
+    }
+
+    if (newValue === "wrap") {
+      onChangeValue({
+        flexWrap: "wrap",
+        flexDirection: "row",
+      });
+      return;
+    }
+
+    onChangeValue({
+      flexWrap: "nowrap",
+      flexDirection: newValue,
+    });
+  };
+
+  return (
+    <ToggleGroup
+      type="single"
+      className="flex gap-[1px] rounded-sm ring-border ring-offset-1 hover:ring-1"
+      value={toggleValue}
+      onValueChange={onValueChange}
+    >
+      <TooltipSimple text="Vertical layout">
+        <div>
+          <ToggleGroupItem
+            size="xs"
+            value="column"
+            aria-label="Vertical layout"
+          >
+            <ArrowDownIcon size={13} />
+          </ToggleGroupItem>
+        </div>
+      </TooltipSimple>
+      <TooltipSimple text="Horizontal layout">
+        <div>
+          <ToggleGroupItem size="xs" value="row" aria-label="Horizontal layout">
+            <ArrowRightIcon size={13} />
+          </ToggleGroupItem>
+        </div>
+      </TooltipSimple>
+      <TooltipSimple text="Wrap">
+        <div>
+          <ToggleGroupItem size="xs" value="wrap" aria-label="Wrap">
+            <CornerDownLeftIcon size={13} />
+          </ToggleGroupItem>
+        </div>
+      </TooltipSimple>
+    </ToggleGroup>
+  );
+}


### PR DESCRIPTION
에디터 상태와 레이아웃을 연동했습니다.

관심사에 따라 `flex-toggle-group.tsx` 과 `align-input.tsx`를 `/editor/ui`에 배치하여,
`layout-setting.tsx`의 복잡도를 줄였습니다.
