### PR TITLE
fix: localhost이 서브도메인으로 인식되지 않도록

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,8 +11,9 @@ export function middleware(request: NextRequest) {
   const searchParams = url.searchParams.toString();
   const path = `${url.pathname}${searchParams ? `?${searchParams}` : ""}`;
 
-  const isSubdomain = (str: string) =>
-    !["www", "invi", "localhost"].includes(str);
+  const isSubdomain = (str: string) => {
+    return !str.startsWith("localhost:") && !["www", "invi"].includes(str);
+  };
 
   const hostnameParts = hostname.split(".");
   const potentialSubdomain = hostnameParts[0];


### PR DESCRIPTION
제 컴에서 localhost:3000이 서브도메인으로 인식해서 대충 고쳐봤어요.
다른 포트를 쓰더라도 서브도메인으로 인식되지 않게 고려했습니다.